### PR TITLE
Serialize tuples as lists

### DIFF
--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -152,6 +152,30 @@ def test_document_boolean_type():
     assert doc.dumps() == "[false]"
     assert doc.as_obj == [False]
 
+def test_document_list_type():
+    doc = Document('[1,2,3,4]')
+    assert doc.dumps() == '[1,2,3,4]'
+    assert doc.as_obj == [1, 2, 3, 4]
+
+    doc = Document([1, 2, 3, 4])
+    assert doc.dumps() == '[1,2,3,4]'
+    assert doc.as_obj == [1, 2, 3, 4]
+
+def test_document_tuple_type():
+    doc = Document(())
+    assert doc.dumps() == '[]'
+
+    doc = Document((1,))
+    assert doc.dumps() == '[1]'
+
+    doc = Document((1, 2, 3, 4))
+    assert doc.dumps() == '[1,2,3,4]'
+
+    doc = Document([(1, 2), (3, 4)])
+    assert doc.dumps() == '[[1,2],[3,4]]'
+
+    doc = Document({'test': (1, 2)})
+    assert doc.dumps() == '{"test":[1,2]}'
 
 def test_document_none_type():
     """

--- a/yyjson/document.c
+++ b/yyjson/document.c
@@ -333,6 +333,8 @@ PyTypeObject *type_for_conversion(PyObject *obj) {
     return &PyDict_Type;
   } else if (obj->ob_type == &PyList_Type) {
     return &PyList_Type;
+  } else if (obj->ob_type == &PyTuple_Type) {
+    return &PyTuple_Type;
   } else if (obj->ob_type == &PyBool_Type) {
     return &PyBool_Type;
   } else if (obj->ob_type == Py_None->ob_type) {
@@ -396,6 +398,19 @@ static inline yyjson_mut_val *mut_primitive_to_element(
     yyjson_mut_val *object_value = NULL;
     for (Py_ssize_t i = 0; i < PyList_GET_SIZE(obj); i++) {
       object_value = mut_primitive_to_element(self, doc, PyList_GET_ITEM(obj, i));
+
+      if (yyjson_unlikely(object_value == NULL)) {
+        return NULL;
+      }
+
+      yyjson_mut_arr_append(val, object_value);
+    }
+    return val;
+  } else if (ob_type == &PyTuple_Type) {
+    yyjson_mut_val *val = yyjson_mut_arr(doc);
+    yyjson_mut_val *object_value = NULL;
+    for (Py_ssize_t i = 0; i < PyTuple_GET_SIZE(obj); i++) {
+      object_value = mut_primitive_to_element(self, doc, PyTuple_GET_ITEM(obj, i));
 
       if (yyjson_unlikely(object_value == NULL)) {
         return NULL;


### PR DESCRIPTION
This PR adds support for serializing Python tuples as lists.