### PR TITLE
Dict keys must be strings

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,13 @@
+coverage:
+  status:
+    project: true
+    patch:
+      default:
+        target: 100%
+
 flag_management:
   default_rules:
     carryforward: true
+
 ignore:
   - "tests/*"

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -166,6 +166,23 @@ def test_document_none_type():
     assert doc.as_obj == [None]
 
 
+def test_document_dict_type():
+    """
+    Ensure we can load and dump the dict type.
+    """
+    doc = Document('{"a": "b"}')
+    assert doc.dumps() == '{"a":"b"}'
+    assert doc.as_obj == {'a': 'b'}
+
+    doc = Document({"a": "b"})
+    assert doc.dumps() == '{"a":"b"}'
+    assert doc.as_obj == {'a': 'b'}
+
+    with pytest.raises(TypeError) as exc:
+        doc = Document({1: 'b'})
+    assert exc.value.args[0] == 'Dictionary keys must be strings'
+
+
 def test_document_get_pointer():
     """
     Ensure JSON pointers work.

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -206,6 +206,10 @@ def test_document_dict_type():
         doc = Document({1: 'b'})
     assert exc.value.args[0] == 'Dictionary keys must be strings'
 
+    with pytest.raises(TypeError) as exc:
+        doc = Document({'\ud83d\ude47': 'foo'})
+    assert exc.value.args[0] == 'Dictionary keys must be strings'
+
 
 def test_document_get_pointer():
     """

--- a/yyjson/document.c
+++ b/yyjson/document.c
@@ -364,6 +364,9 @@ static inline yyjson_mut_val *mut_primitive_to_element(
   if (ob_type == &PyUnicode_Type) {
     Py_ssize_t str_len;
     const char *str = PyUnicode_AsUTF8AndSize(obj, &str_len);
+    if (yyjson_unlikely(str == NULL)) {
+      return NULL;
+    }
     return yyjson_mut_strncpy(doc, str, str_len);
   } else if (ob_type == &PyLong_Type) {
     // Serialization of integers is a little special, since Python allows
@@ -413,6 +416,13 @@ static inline yyjson_mut_val *mut_primitive_to_element(
     while (PyDict_Next(obj, &i, &key, &value)) {
       Py_ssize_t str_len;
       const char *str = PyUnicode_AsUTF8AndSize(key, &str_len);
+      if (yyjson_unlikely(str == NULL && PyErr_Occurred())) {
+        PyErr_Format(PyExc_TypeError,
+            "Dictionary keys must be strings",
+            Py_TYPE(obj)->tp_name
+        );
+        return NULL;
+      }
       object_value = mut_primitive_to_element(self, doc, value);
       if (yyjson_unlikely(object_value == NULL)) {
         return NULL;

--- a/yyjson/document.c
+++ b/yyjson/document.c
@@ -428,7 +428,7 @@ static inline yyjson_mut_val *mut_primitive_to_element(
     while (PyDict_Next(obj, &i, &key, &value)) {
       Py_ssize_t str_len;
       const char *str = PyUnicode_AsUTF8AndSize(key, &str_len);
-      if (yyjson_unlikely(str == NULL && PyErr_Occurred())) {
+      if (yyjson_unlikely(str == NULL) && PyErr_Occurred()) {
         PyErr_Format(PyExc_TypeError,
             "Dictionary keys must be strings",
             Py_TYPE(obj)->tp_name

--- a/yyjson/document.c
+++ b/yyjson/document.c
@@ -366,9 +366,6 @@ static inline yyjson_mut_val *mut_primitive_to_element(
   if (ob_type == &PyUnicode_Type) {
     Py_ssize_t str_len;
     const char *str = PyUnicode_AsUTF8AndSize(obj, &str_len);
-    if (yyjson_unlikely(str == NULL)) {
-      return NULL;
-    }
     return yyjson_mut_strncpy(doc, str, str_len);
   } else if (ob_type == &PyLong_Type) {
     // Serialization of integers is a little special, since Python allows

--- a/yyjson/document.c
+++ b/yyjson/document.c
@@ -428,7 +428,7 @@ static inline yyjson_mut_val *mut_primitive_to_element(
     while (PyDict_Next(obj, &i, &key, &value)) {
       Py_ssize_t str_len;
       const char *str = PyUnicode_AsUTF8AndSize(key, &str_len);
-      if (yyjson_unlikely(str == NULL) && PyErr_Occurred()) {
+      if (yyjson_unlikely(str == NULL)) {
         PyErr_Format(PyExc_TypeError,
             "Dictionary keys must be strings",
             Py_TYPE(obj)->tp_name


### PR DESCRIPTION
This PR fixes a bug that would cause a `SystemError` when serializing dictionaries with keys that weren't strings.