### PR TITLE
LICENSE + packaging updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -191,7 +191,7 @@ jobs:
   deploy_pypi_linux:
 
     docker:
-      - image: cimg/python:3.12
+      - image: cimg/python:3.13
         environment:
           PYPI_SMOKE_CODE: import yyjson; print(yyjson.__package__)
 
@@ -232,6 +232,15 @@ workflows:
               only: /.*/
 
       - python3:
+          name: python312
+          python-version: "3.12"
+          filters:
+            tags:
+              only: /.*/
+            branches:
+              only: /.*/
+
+      - python3:
           name: python313
           python-version: "3.13"
           filters:
@@ -243,6 +252,7 @@ workflows:
       - deploy_pypi_linux:
           requires:
             - python311
+            - python312
             - python313
           context:
             - PublicPypiAccess
@@ -255,6 +265,7 @@ workflows:
       - deploy_pypi_macos:
           requires:
             - python311
+            - python312
             - python313
           context:
             - PublicPypiAccess

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,5 @@
 Copyright (c) 2020 Tyler Kennedy
+Copyright (c) 2025 The Vertex Project LLC
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,23 +8,18 @@ version = "4.1.1"
 description = "JSON parser & serializer built on yyjson"
 readme = "README.md"
 authors = [
+    {name = "The Vertex Project LLC", email = "root@vertex.link" },
     {name = "Tyler Kennedy", email = "tk@tkte.ch" },
-    {name = "The Vertex Project LLC", email = "root@vertex.link" }
 ]
-license = { file= "LICENSE" }
+license = "MIT"
+license-files = [ "LICENSE" ]
 keywords = ["json", "parser", "serializer", "patcher"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
-    "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
-    "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: Implementation :: CPython",
-    "Programming Language :: Python :: Implementation :: PyPy",
     "Operating System :: OS Independent",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: Implementation :: CPython",
     "Operating System :: OS Independent",
@@ -49,8 +50,8 @@ packages = ["yyjson"]
 test-command = [ 'python -c "import yyjson; print(yyjson.__package__)"' ]
 
 [tool.cibuildwheel.linux]
-build = "cp311-manylinux_x86_64 cp313-manylinux_x86_64"
+build = "cp311-manylinux_x86_64 cp312-manylinux_x86_64 cp313-manylinux_x86_64"
 
 [tool.cibuildwheel.macos]
 archs = "universal2"
-build = "cp311-* cp313-*"
+build = "cp311-* cp312-* cp313-*"


### PR DESCRIPTION
- update license field to be PEP639 compliant
- add license-files to declare the license file to include in packages
- update LICENSE to include vertex project llc
- run LICENSE file through dos2unix
- remove trove classifiers for python packages we don't publish wheels for
- invert authors list so that vtx shows up first in pyp
- Add python 3.12 support since it should be cheap / free